### PR TITLE
ログイン後のページ遷移エラーの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ https://siplog.vercel.app
 
 ## 使用技術
 
-| Category       | Technology Stack                                    |
-| -------------- | --------------------------------------------------- |
-| Frontend       | TypeScript, Next.js, TailwindCss                    |
-| Backend        | TypeScript, Next.js, Prisma                         |
-| Infrastructure | Vercel, Supabase                                    |
-| Database       | PostgreSQL                                          |
-| Design         | Figma                                               |
-| etc.           | react-hook-form, zod, ESLint, Prettier, Git, GitHub |
+| Category       | Technology Stack                                                           |
+| -------------- | -------------------------------------------------------------------------- |
+| Frontend       | TypeScript, Next.js, TailwindCss                                           |
+| Backend        | TypeScript, Next.js, Prisma                                                |
+| Infrastructure | Vercel, Supabase                                                           |
+| Database       | PostgreSQL                                                                 |
+| Design         | Figma                                                                      |
+| etc.           | react-hook-form, zod, Jest, testing-library, ESLint, Prettier, Git, GitHub |
 
 <br/>
 

--- a/src/app/(loginSignin)/login/page.tsx
+++ b/src/app/(loginSignin)/login/page.tsx
@@ -33,7 +33,7 @@ export default function Page() {
       alert('ログインに失敗しました。入力内容を確認し再度ログインしてください。');
       return;
     } else {
-      // router.replace('/users');
+      router.replace('/users');
       console.log('ログインに成功しました');
     }
   }


### PR DESCRIPTION
ログイン後のページ遷移について、router.replace('')がコメントアウトしたままだったのでコメントアウトを解除しページ遷移が正常に行われるように修正